### PR TITLE
Consolidate logic so that S3OutputStream only throw IOExceptions and not Kafka-specific exceptions (was only in one place)

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -671,9 +671,11 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   protected S3SinkConnectorConfig(ConfigDef configDef, Map<String, String> props) {
     super(configDef, props);
     ConfigDef storageCommonConfigDef = StorageCommonConfig.newConfigDef(STORAGE_CLASS_RECOMMENDER);
-    StorageCommonConfig commonConfig = new StorageCommonConfig(storageCommonConfigDef, originalsStrings());
+    StorageCommonConfig commonConfig = new StorageCommonConfig(storageCommonConfigDef,
+        originalsStrings());
     ConfigDef partitionerConfigDef = PartitionerConfig.newConfigDef(PARTITIONER_CLASS_RECOMMENDER);
-    PartitionerConfig partitionerConfig = new PartitionerConfig(partitionerConfigDef, originalsStrings());
+    PartitionerConfig partitionerConfig = new PartitionerConfig(partitionerConfigDef,
+        originalsStrings());
 
     this.name = parseName(originalsStrings());
     addToGlobal(partitionerConfig);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -174,9 +174,6 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   private final String name;
 
-  private final StorageCommonConfig commonConfig;
-  private final PartitionerConfig partitionerConfig;
-
   private final Map<String, ComposableConfig> propertyToConfig = new HashMap<>();
   private final Set<AbstractConfig> allConfigs = new HashSet<>();
 
@@ -212,13 +209,13 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   static {
     STORAGE_CLASS_RECOMMENDER.addValidValues(
-        Arrays.<Object>asList(S3Storage.class)
+        Collections.singletonList(S3Storage.class)
     );
 
     FORMAT_CLASS_RECOMMENDER.addValidValues(FORMAT_CLASS_VALID_VALUES);
 
     PARTITIONER_CLASS_RECOMMENDER.addValidValues(
-        Arrays.<Object>asList(
+        Arrays.asList(
             DefaultPartitioner.class,
             HourlyPartitioner.class,
             DailyPartitioner.class,
@@ -674,9 +671,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   protected S3SinkConnectorConfig(ConfigDef configDef, Map<String, String> props) {
     super(configDef, props);
     ConfigDef storageCommonConfigDef = StorageCommonConfig.newConfigDef(STORAGE_CLASS_RECOMMENDER);
-    commonConfig = new StorageCommonConfig(storageCommonConfigDef, originalsStrings());
+    StorageCommonConfig commonConfig = new StorageCommonConfig(storageCommonConfigDef, originalsStrings());
     ConfigDef partitionerConfigDef = PartitionerConfig.newConfigDef(PARTITIONER_CLASS_RECOMMENDER);
-    partitionerConfig = new PartitionerConfig(partitionerConfigDef, originalsStrings());
+    PartitionerConfig partitionerConfig = new PartitionerConfig(partitionerConfigDef, originalsStrings());
 
     this.name = parseName(originalsStrings());
     addToGlobal(partitionerConfig);
@@ -854,7 +851,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   private static class RegionRecommender implements ConfigDef.Recommender {
     @Override
     public List<Object> validValues(String name, Map<String, Object> connectorConfigs) {
-      return Arrays.<Object>asList(RegionUtils.getRegions());
+      return Collections.singletonList(RegionUtils.getRegions());
     }
 
     @Override

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -163,21 +163,13 @@ public class S3OutputStream extends PositionOutputStream {
       multiPartUpload.complete();
       log.debug("Upload complete for bucket '{}' key '{}'", bucket, key);
     } catch (IOException e) {
-      // Catch here in order to log this specific error and then rethrow
-      // with a more specific message (message may be used for error mapping).
-      String msg = String.format(
-          "Multipart upload failed to complete for bucket '%s' key '%s'. Reason: %s",
+      log.error(
+          "Multipart upload failed to complete for bucket '{}' key '{}'. Reason: {}",
           bucket,
           key,
           e.getMessage()
       );
-      log.error("{}", msg);
-      IOException newIoException = new IOException(msg, e.getCause()) ;
-      // Set original exception's stack trace
-      newIoException.setStackTrace(e.getStackTrace());
-      // Throw the new IOException with updated message and the original cause
-      // (cause is most likely an AmazonClientException)
-      throw newIoException;
+      throw e;
     } finally {
       buffer.clear();
       multiPartUpload = null;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/S3ErrorUtils.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/S3ErrorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -18,7 +18,6 @@ package io.confluent.connect.s3.util;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.retry.PredefinedRetryPolicies;
-import io.confluent.connect.storage.common.util.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
@@ -70,13 +69,11 @@ public class S3ErrorUtils {
   /**
    * Return a `ConnectException` exception which may or may not
    * be of (or derived from) type `RetriableException`.
-   * @param message Optional message (can be null)
    * @param t The exception to analyze
    * @return an exception of (or derived from) `ConnectException` which
    *         may also be of type `RetriableException`.
    */
   public static ConnectException maybeRetriableConnectException(
-      String message,
       Throwable t
   ) {
     // If this is already a ConnectException of some sort, just rethrow it
@@ -84,24 +81,8 @@ public class S3ErrorUtils {
       return (ConnectException) t;
     }
     if (isRetriableException(t)) {
-      return StringUtils.isNotBlank(message)
-          ? new RetriableException(message, t) : new RetriableException(t);
+      return new RetriableException(t.getMessage(), t);
     }
-    return StringUtils.isNotBlank(message)
-        ? new ConnectException(message, t) : new ConnectException(t);
+    return new ConnectException(t.getMessage(), t);
   }
-
-  /**
-   * Return a `ConnectException` exception which may or may not
-   * be of (or derived from) type `RetriableException`.
-   * @param t The exception to analyze
-   * @return an exception of (or derived from) `ConnectException` which
-   *         may also be of type `RetriableException`.
-   */
-  public static ConnectException maybeRetriableConnectException(
-      Throwable t
-  ) {
-    return maybeRetriableConnectException(null, t);
-  }
-
 }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamTest.java
@@ -10,43 +10,53 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonServiceException.ErrorType;
 import com.amazonaws.services.s3.AmazonS3;
 import io.confluent.connect.s3.S3SinkConnectorTestBase;
-import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.IOException;
 
 public class S3OutputStreamTest extends S3SinkConnectorTestBase {
 
   private AmazonS3 s3Mock;
   private S3OutputStream stream;
+  final static String S3_TEST_KEY_NAME = "key";
+  final static String S3_EXCEPTION_MESSAGE = "this is an s3 exception";
+  final String EXPECTED_EXCEPTION_MESSAGE = String.format(
+      "Multipart upload failed to complete for bucket '%s' key '%s'. Reason: %s",
+      S3_TEST_BUCKET_NAME,
+      S3_TEST_KEY_NAME,
+      S3_EXCEPTION_MESSAGE
+  );
+
 
   @Before
   public void before() throws Exception {
     super.setUp();
     s3Mock = mock(AmazonS3.class);
-    stream = new S3OutputStream("key", connectorConfig, s3Mock);
+    stream = new S3OutputStream(S3_TEST_KEY_NAME, connectorConfig, s3Mock);
   }
 
   @Test
   public void testPropagateUnretriableS3Exceptions() {
-    AmazonServiceException e = new AmazonServiceException("this is an s3 exception");
+    AmazonServiceException e = new AmazonServiceException(S3_EXCEPTION_MESSAGE);
     e.setErrorType(ErrorType.Client);
 
     when(s3Mock.initiateMultipartUpload(any())).thenThrow(e);
-    assertThrows("Unable to initiate Multipart Upload.", ConnectException.class, () -> stream.commit());
+    assertThrows(EXPECTED_EXCEPTION_MESSAGE, IOException.class, () -> stream.commit());
   }
 
   @Test
   public void testPropagateRetriableS3Exceptions() {
-    AmazonServiceException e = new AmazonServiceException("this is an s3 exception");
+    AmazonServiceException e = new AmazonServiceException(S3_EXCEPTION_MESSAGE);
     e.setErrorType(ErrorType.Service);
 
     when(s3Mock.initiateMultipartUpload(any())).thenThrow(e);
-    assertThrows("Multipart upload failed to complete.", ConnectException.class, () -> stream.commit());
+    assertThrows(EXPECTED_EXCEPTION_MESSAGE, IOException.class, () -> stream.commit());
   }
 
   @Test
   public void testPropagateOtherRetriableS3Exceptions() {
-    when(s3Mock.initiateMultipartUpload(any())).thenThrow(new AmazonClientException("this is an other s3 exception"));
-    assertThrows("Multipart upload failed to complete.", ConnectException.class, () -> stream.commit());
+    when(s3Mock.initiateMultipartUpload(any())).thenThrow(new AmazonClientException(S3_EXCEPTION_MESSAGE));
+    assertThrows(EXPECTED_EXCEPTION_MESSAGE, IOException.class, () -> stream.commit());
   }
 }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamTest.java
@@ -21,12 +21,6 @@ public class S3OutputStreamTest extends S3SinkConnectorTestBase {
   private S3OutputStream stream;
   final static String S3_TEST_KEY_NAME = "key";
   final static String S3_EXCEPTION_MESSAGE = "this is an s3 exception";
-  final String EXPECTED_EXCEPTION_MESSAGE = String.format(
-      "Multipart upload failed to complete for bucket '%s' key '%s'. Reason: %s",
-      S3_TEST_BUCKET_NAME,
-      S3_TEST_KEY_NAME,
-      S3_EXCEPTION_MESSAGE
-  );
 
 
   @Before
@@ -42,7 +36,7 @@ public class S3OutputStreamTest extends S3SinkConnectorTestBase {
     e.setErrorType(ErrorType.Client);
 
     when(s3Mock.initiateMultipartUpload(any())).thenThrow(e);
-    assertThrows(EXPECTED_EXCEPTION_MESSAGE, IOException.class, () -> stream.commit());
+    assertThrows(IOException.class, () -> stream.commit());
   }
 
   @Test
@@ -51,12 +45,12 @@ public class S3OutputStreamTest extends S3SinkConnectorTestBase {
     e.setErrorType(ErrorType.Service);
 
     when(s3Mock.initiateMultipartUpload(any())).thenThrow(e);
-    assertThrows(EXPECTED_EXCEPTION_MESSAGE, IOException.class, () -> stream.commit());
+    assertThrows(IOException.class, () -> stream.commit());
   }
 
   @Test
   public void testPropagateOtherRetriableS3Exceptions() {
     when(s3Mock.initiateMultipartUpload(any())).thenThrow(new AmazonClientException(S3_EXCEPTION_MESSAGE));
-    assertThrows(EXPECTED_EXCEPTION_MESSAGE, IOException.class, () -> stream.commit());
+    assertThrows(IOException.class, () -> stream.commit());
   }
 }


### PR DESCRIPTION


## Problem


## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
